### PR TITLE
Remove unused column variable

### DIFF
--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/MergeRegionCalculator.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/MergeRegionCalculator.java
@@ -19,12 +19,11 @@ public class MergeRegionCalculator {
         int rowCount = flatRows.size();
 
         for (int col = 0; col < columnOrder.size(); col++) {
-            String column = columnOrder.get(col);
             Object prev = null;
             int blockStart = 0;
 
             for (int i = 0; i < rowCount; i++) {
-                Object curr = flatRows.get(i).getColumns().get(column);
+                Object curr = flatRows.get(i).getColumns().get(columnOrder.get(col));
 
                 if (!Objects.equals(prev, curr)) {
                     // 이전 블록이 2개 이상 연속이면 병합해야 함


### PR DESCRIPTION
## Summary
- remove redundant local `column` variable in MergeRegionCalculator

## Testing
- `javac com/pandaterry/application/service/excel/MergeRegionCalculator.java`
- `./gradlew test --no-daemon`