### PR TITLE
Add join key parsing and merge integration

### DIFF
--- a/agent-client/agent-server/build.gradle
+++ b/agent-client/agent-server/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     testImplementation("io.micronaut:micronaut-http-client")
     implementation("org.postgresql:postgresql")
     implementation("com.alibaba:easyexcel:3.3.2")
+    implementation("com.github.jsqlparser:jsqlparser:4.5")
     compileOnly("org.projectlombok:lombok:1.18.30")
     annotationProcessor("org.projectlombok:lombok:1.18.30")
     

--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/ExcelHierarchyExporter.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/ExcelHierarchyExporter.java
@@ -14,9 +14,15 @@ import java.util.stream.Collectors;
 public class ExcelHierarchyExporter {
 
     public void export(List<FlatRow> flatRows, List<String> columnOrder, OutputStream out) {
-        // 1) flatRows를 List<List<Object>> 형식으로 변환 (각 FlatRow → columnOrder 순서대로 value만 뽑아낸다)
+        export(flatRows, columnOrder, Collections.emptyList(), out);
+    }
+
+    public void export(List<FlatRow> flatRows, List<String> columnOrder, List<String> joinKeyOrder, OutputStream out) {
+        List<String> finalOrder = buildFinalOrder(columnOrder, joinKeyOrder);
+
+        // 1) flatRows를 List<List<Object>> 형식으로 변환 (각 FlatRow → finalOrder 순서대로 value만 뽑아낸다)
         List<List<Object>> rowData = flatRows.stream()
-                .map(row -> columnOrder.stream()
+                .map(row -> finalOrder.stream()
                         .map(colName -> row.getColumns().get(colName))
                         .collect(Collectors.toList())
                 )
@@ -24,16 +30,23 @@ public class ExcelHierarchyExporter {
 
         // 2) 병합 범위 계산 (CellRange(start1Base, end1Base)) 반환
         MergeRegionCalculator calc = new MergeRegionCalculator();
-        Map<Integer, List<CellRange>> mergeRegions = calc.calculateMergeRegions(flatRows, columnOrder);
+        Map<Integer, List<CellRange>> mergeRegions = calc.calculateMergeRegions(flatRows, finalOrder);
 
         // 3) EasyExcel로 쓰기
-        //    - .head(generateHead(columnOrder)) 로 헤더를 작성
-        //    - .registerWriteHandler(new MergeStrategy(mergeRegions)) 로 병합 전략 등록
         EasyExcel.write(out)
-                .head(generateHead(columnOrder))
+                .head(generateHead(finalOrder))
                 .registerWriteHandler(new MergeStrategy(mergeRegions))
                 .sheet("Sheet1")
                 .doWrite(rowData);
+    }
+
+    private List<String> buildFinalOrder(List<String> columnOrder, List<String> joinKeyOrder) {
+        if (joinKeyOrder == null || joinKeyOrder.isEmpty()) {
+            return new ArrayList<>(columnOrder);
+        }
+        LinkedHashSet<String> set = new LinkedHashSet<>(joinKeyOrder);
+        set.addAll(columnOrder);
+        return new ArrayList<>(set);
     }
 
     /** columnOrder(e.g. ["회사","부서",...])를 EasyExcel 헤더 형식(List<List<String>>)으로 변환 */

--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/JoinKeyOrderParser.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/JoinKeyOrderParser.java
@@ -1,0 +1,54 @@
+package com.pandaterry.application.service.excel;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.Join;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Utility class extracting join key order from a SELECT query using JSQLParser.
+ */
+public class JoinKeyOrderParser {
+
+    /**
+     * Parses given SQL and returns the left column of each JOIN condition in order.
+     * When parsing fails or no JOIN clause exists, an empty list is returned.
+     */
+    public List<String> parseJoinKeys(String sql) {
+        try {
+            Statement stmt = CCJSqlParserUtil.parse(sql);
+            if (!(stmt instanceof Select select)) {
+                return Collections.emptyList();
+            }
+            if (!(select.getSelectBody() instanceof PlainSelect plain)) {
+                return Collections.emptyList();
+            }
+            List<Join> joins = plain.getJoins();
+            if (joins == null || joins.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<String> keys = new ArrayList<>();
+            for (Join join : joins) {
+                Expression onExpr = join.getOnExpression();
+                if (onExpr instanceof EqualsTo eq) {
+                    Expression left = eq.getLeftExpression();
+                    if (left instanceof Column col) {
+                        keys.add(col.getFullyQualifiedName());
+                    }
+                }
+            }
+            return keys;
+        } catch (JSQLParserException e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/MergeRegionCalculator.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/excel/MergeRegionCalculator.java
@@ -15,11 +15,17 @@ public class MergeRegionCalculator {
      */
     public Map<Integer, List<CellRange>> calculateMergeRegions(
             List<FlatRow> flatRows, List<String> columnOrder) {
+        return calculateMergeRegions(flatRows, columnOrder, Collections.emptyList());
+    }
+
+    public Map<Integer, List<CellRange>> calculateMergeRegions(
+            List<FlatRow> flatRows, List<String> columnOrder, List<String> joinKeyOrder) {
+        List<String> finalOrder = buildFinalOrder(columnOrder, joinKeyOrder);
+
         Map<Integer, List<CellRange>> mergeMap = new HashMap<>();
         int rowCount = flatRows.size();
-
-        for (int col = 0; col < columnOrder.size(); col++) {
-            String column = columnOrder.get(col);
+        for (int col = 0; col < finalOrder.size(); col++) {
+            String column = finalOrder.get(col);
             Object prev = null;
             int blockStart = 0;
 
@@ -49,5 +55,14 @@ public class MergeRegionCalculator {
             }
         }
         return mergeMap;
+    }
+
+    private List<String> buildFinalOrder(List<String> columnOrder, List<String> joinKeyOrder) {
+        if (joinKeyOrder == null || joinKeyOrder.isEmpty()) {
+            return new ArrayList<>(columnOrder);
+        }
+        LinkedHashSet<String> set = new LinkedHashSet<>(joinKeyOrder);
+        set.addAll(columnOrder);
+        return new ArrayList<>(set);
     }
 }

--- a/agent-client/agent-server/src/test/java/com/pandaterry/application/service/JoinKeyMergeIntegrationTest.java
+++ b/agent-client/agent-server/src/test/java/com/pandaterry/application/service/JoinKeyMergeIntegrationTest.java
@@ -1,0 +1,77 @@
+package com.pandaterry.application.service;
+
+import com.pandaterry.application.service.excel.ExcelHierarchyExporter;
+import com.pandaterry.application.service.excel.JoinKeyOrderParser;
+import com.pandaterry.application.service.excel.MergeRegionCalculator;
+import com.pandaterry.application.vo.CellRange;
+import com.pandaterry.application.vo.FlatRow;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.junit.jupiter.api.Test;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.io.OutputStream;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JoinKeyMergeIntegrationTest {
+
+    @Test
+    void joinKeyBasedMerge() throws Exception {
+        String sql = "SELECT a.id as \"a.id\", b.id as \"b.id\", c.name FROM a JOIN b ON a.id = b.a_id JOIN c ON b.id = c.b_id";
+        JoinKeyOrderParser parser = new JoinKeyOrderParser();
+        List<String> joinKeys = parser.parseJoinKeys(sql);
+
+        List<String> columns = List.of("a.id", "b.id", "c.name");
+
+        FlatRow r1 = new FlatRow();
+        r1.getColumns().put("a.id", 1);
+        r1.getColumns().put("b.id", 10);
+        r1.getColumns().put("c.name", "x");
+
+        FlatRow r2 = new FlatRow();
+        r2.getColumns().put("a.id", 1);
+        r2.getColumns().put("b.id", 10);
+        r2.getColumns().put("c.name", "y");
+
+        FlatRow r3 = new FlatRow();
+        r3.getColumns().put("a.id", 1);
+        r3.getColumns().put("b.id", 20);
+        r3.getColumns().put("c.name", "z");
+
+        FlatRow r4 = new FlatRow();
+        r4.getColumns().put("a.id", 2);
+        r4.getColumns().put("b.id", 30);
+        r4.getColumns().put("c.name", "p");
+
+        List<FlatRow> flatRows = List.of(r1, r2, r3, r4);
+
+        MergeRegionCalculator calc = new MergeRegionCalculator();
+        Map<Integer, List<CellRange>> mergeMap = calc.calculateMergeRegions(flatRows, columns, joinKeys);
+        assertThat(mergeMap.get(0)).containsExactly(new CellRange(2,4));
+        assertThat(mergeMap.get(1)).containsExactly(new CellRange(2,3));
+
+        Path outputDir = Paths.get("src/test/resources/output");
+        Files.createDirectories(outputDir);
+        Path outputFile = outputDir.resolve("join_key_merge.xlsx");
+
+        try (OutputStream os = Files.newOutputStream(outputFile)) {
+            ExcelHierarchyExporter exporter = new ExcelHierarchyExporter();
+            exporter.export(flatRows, columns, joinKeys, os);
+        }
+
+        try (Workbook wb = WorkbookFactory.create(Files.newInputStream(outputFile))) {
+            Sheet sheet = wb.getSheetAt(0);
+            List<String> merged = new ArrayList<>();
+            for (int i = 0; i < sheet.getNumMergedRegions(); i++) {
+                CellRangeAddress addr = sheet.getMergedRegion(i);
+                merged.add(addr.formatAsString());
+            }
+            assertThat(merged).containsExactlyInAnyOrder("A2:A4", "B2:B3");
+        }
+    }
+}

--- a/agent-client/agent-server/src/test/java/com/pandaterry/application/service/JoinKeyOrderParserTest.java
+++ b/agent-client/agent-server/src/test/java/com/pandaterry/application/service/JoinKeyOrderParserTest.java
@@ -1,0 +1,19 @@
+package com.pandaterry.application.service;
+
+import com.pandaterry.application.service.excel.JoinKeyOrderParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JoinKeyOrderParserTest {
+
+    @Test
+    void parseJoinKeys_simpleQuery() {
+        String sql = "SELECT a.id, b.id FROM table_a a JOIN table_b b ON a.id = b.a_id JOIN table_c c ON b.id = c.b_id";
+        JoinKeyOrderParser parser = new JoinKeyOrderParser();
+        List<String> keys = parser.parseJoinKeys(sql);
+        assertThat(keys).containsExactly("a.id", "b.id");
+    }
+}


### PR DESCRIPTION
## Summary
- parse JOIN keys using JSQLParser
- allow `ExcelHierarchyExporter` and `MergeRegionCalculator` to reorder
  columns when join keys are provided
- add tests for parser and integration of join-key merges
- add jsqlparser dependency to agent module

## Testing
- `./gradlew test` 