### PR TITLE
로컬 업로드 클라이언트 추가

### DIFF
--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/query/JobExecutionService.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/query/JobExecutionService.java
@@ -2,6 +2,7 @@ package com.pandaterry.application.service.query;
 
 import com.pandaterry.application.service.excel.ExcelHierarchyExporter;
 import com.pandaterry.application.vo.FlatRow;
+import com.pandaterry.infrastructure.client.UploadClient;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
@@ -16,16 +17,24 @@ import java.util.UUID;
 @Singleton
 public class JobExecutionService {
 
+    private final SimpleSqlExecutor sqlExecutor;
+    private final ExcelHierarchyExporter excelExporter;
+    private final UploadClient uploadClient;
+
     @Inject
-    private SimpleSqlExecutor sqlExecutor;
-    @Inject
-    private ExcelHierarchyExporter excelExporter;
+    public JobExecutionService(SimpleSqlExecutor sqlExecutor,
+                               ExcelHierarchyExporter excelExporter,
+                               UploadClient uploadClient) {
+        this.sqlExecutor = sqlExecutor;
+        this.excelExporter = excelExporter;
+        this.uploadClient = uploadClient;
+    }
 
     /**
-     * SQL을 실행하고 결과를 엑셀 파일로 저장
-     * 결과가 없을 경우 Optional.empty()를 반환.
+     * SQL을 실행하고 결과 엑셀 파일을 업로드한다.
+     * 결과가 없으면 null을 반환한다.
      */
-    public Path execute(UUID datasourceId, String sql, UUID jobId) throws Exception {
+    public String execute(UUID datasourceId, String sql, UUID jobId) throws Exception {
         List<Map<String, Object>> rows = sqlExecutor.execute(datasourceId, sql);
         if (rows.isEmpty()) {
             return null;
@@ -43,6 +52,6 @@ public class JobExecutionService {
         try (OutputStream os = Files.newOutputStream(temp)) {
             excelExporter.export(flatRows, columnOrder, os);
         }
-        return temp;
+        return uploadClient.upload(temp);
     }
 }

--- a/agent-client/agent-server/src/main/java/com/pandaterry/application/service/query/QueryJobProcessor.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/application/service/query/QueryJobProcessor.java
@@ -26,7 +26,7 @@ public class QueryJobProcessor {
     @Inject
     private JobExecutionService jobExecutionService;
 
-    public Optional<Path> requestAndProcess(UUID orgId, UUID agentId, UUID datasourceId, String naturalText) {
+    public Optional<String> requestAndProcess(UUID orgId, UUID agentId, UUID datasourceId, String naturalText) {
         Optional<ExecutionJob> created = queryServiceClient.requestQuery(orgId, new QueryRequest(naturalText));
         if (created.isEmpty()) {
             return Optional.empty();
@@ -37,13 +37,13 @@ public class QueryJobProcessor {
             return Optional.empty();
         }
         try {
-            Path excel = jobExecutionService.execute(datasourceId, job.query(), jobId);
-            if (excel == null) {
+            String downloadUrl = jobExecutionService.execute(datasourceId, job.query(), jobId);
+            if (downloadUrl == null) {
                 queryServiceClient.reportJobResult(jobId, new JobResultRequest(job.jobId(), JobStatus.FAILED, null, "empty result"));
                 return Optional.empty();
             }
-            queryServiceClient.reportJobResult(jobId, new JobResultRequest(job.jobId(), JobStatus.COMPLETED, excel.toString(), null));
-            return Optional.of(excel);
+            queryServiceClient.reportJobResult(jobId, new JobResultRequest(job.jobId(), JobStatus.COMPLETED, downloadUrl, null));
+            return Optional.of(downloadUrl);
         } catch (Exception e) {
             log.error("failed to execute job", e);
             queryServiceClient.reportJobResult(jobId, new JobResultRequest(job.jobId(), JobStatus.FAILED, null, e.getMessage()));

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/LocalUploadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/LocalUploadClient.java
@@ -1,0 +1,33 @@
+package com.pandaterry.infrastructure.client;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * 로컬 파일 시스템에 결과 파일을 저장하는 구현체.
+ */
+@Requires(property = "storage.type", value = "local")
+@Singleton
+public class LocalUploadClient implements UploadClient {
+
+    private final String localDir;
+
+    public LocalUploadClient(@Value("${storage.local-path}") String localDir) {
+        this.localDir = localDir;
+    }
+
+    @Override
+    public String upload(Path filePath) throws Exception {
+        Path dir = Paths.get(localDir);
+        Files.createDirectories(dir);
+        Path dest = dir.resolve(filePath.getFileName());
+        Files.move(filePath, dest, StandardCopyOption.REPLACE_EXISTING);
+        return dest.toUri().toString();
+    }
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/PresignedUrlUploadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/PresignedUrlUploadClient.java
@@ -1,0 +1,40 @@
+package com.pandaterry.infrastructure.client;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.client.HttpClient;
+import jakarta.inject.Singleton;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * 프리사인 URL을 이용해 파일을 업로드하는 기본 구현체.
+ */
+@Requires(property = "storage.type", value = "s3")
+@Singleton
+public class PresignedUrlUploadClient implements UploadClient {
+
+    private final HttpClient httpClient;
+    private final String presignedPutUrl;
+    private final String downloadUrl;
+
+    public PresignedUrlUploadClient(HttpClient httpClient,
+                                    @Value("${storage.presigned-put-url}") String presignedPutUrl,
+                                    @Value("${storage.download-url}") String downloadUrl) {
+        this.httpClient = httpClient;
+        this.presignedPutUrl = presignedPutUrl;
+        this.downloadUrl = downloadUrl;
+    }
+
+    @Override
+    public String upload(Path filePath) throws Exception {
+        byte[] bytes = Files.readAllBytes(filePath);
+        HttpRequest<byte[]> req = HttpRequest.PUT(presignedPutUrl, bytes)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM);
+        httpClient.toBlocking().exchange(req);
+        return downloadUrl;
+    }
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/UploadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/UploadClient.java
@@ -1,0 +1,13 @@
+package com.pandaterry.infrastructure.client;
+
+import java.nio.file.Path;
+
+/**
+ * 파일 업로드를 담당하는 클라이언트 인터페이스.
+ */
+public interface UploadClient {
+    /**
+     * 지정한 파일을 업로드 후 다운로드 URL을 반환한다.
+     */
+    String upload(Path filePath) throws Exception;
+}

--- a/agent-client/agent-server/src/main/resources/application.yml
+++ b/agent-client/agent-server/src/main/resources/application.yml
@@ -21,3 +21,9 @@ services:
     base-url: http://localhost:8082
   quota-service:
     base-url: http://localhost:8083
+
+storage:
+  type: local
+  local-path: ./uploads
+  presigned-put-url: http://localhost:9000/put
+  download-url: http://localhost:9000/download

--- a/agent-client/agent-server/src/test/java/com/pandaterry/application/service/query/JobExecutionServiceTest.java
+++ b/agent-client/agent-server/src/test/java/com/pandaterry/application/service/query/JobExecutionServiceTest.java
@@ -1,0 +1,40 @@
+package com.pandaterry.application.service.query;
+
+import com.pandaterry.application.service.excel.ExcelHierarchyExporter;
+import com.pandaterry.infrastructure.client.UploadClient;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class JobExecutionServiceTest {
+
+    @Test
+    void execute_업로드호출() throws Exception {
+        SimpleSqlExecutor sqlExecutor = mock(SimpleSqlExecutor.class);
+        ExcelHierarchyExporter exporter = mock(ExcelHierarchyExporter.class);
+        UploadClient uploadClient = mock(UploadClient.class);
+
+        JobExecutionService service = new JobExecutionService(sqlExecutor, exporter, uploadClient);
+
+        UUID dsId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+
+        when(sqlExecutor.execute(dsId, "select 1"))
+                .thenReturn(List.of(Map.of("a", 1)));
+        when(uploadClient.upload(any(Path.class))).thenReturn("http://download");
+
+        String url = service.execute(dsId, "select 1", jobId);
+
+        verify(sqlExecutor).execute(dsId, "select 1");
+        verify(exporter).export(any(), any(), any());
+        verify(uploadClient).upload(any(Path.class));
+        assertThat(url).isEqualTo("http://download");
+    }
+}


### PR DESCRIPTION
## Summary
- 로컬 파일 시스템에 업로드하는 `LocalUploadClient` 구현을 도입했습니다.
- `PresignedUrlUploadClient`는 `storage.type`이 `s3`일 때만 활성화되도록 수정했습니다.
- 설정 파일에 저장소 타입과 로컬 경로를 추가했습니다.
