### PR TITLE
Datasource 생성자 수정 및 테스트 추가

### DIFF
--- a/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/domain/entity/Datasource.java
+++ b/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/domain/entity/Datasource.java
@@ -57,6 +57,8 @@ public class Datasource {
         this.name = name;
         this.dbType = dbType;
         this.engineType = engineType;
+        this.createdByUser = userId;
+        this.createdByAgent = agentId;
     }
 
     public static Datasource create(UUID orgId, String name, DatabaseType dbType, DatabaseEngineType engineType, UUID userId, UUID agentId) {

--- a/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/unit/domain/entity/DatasourceTest.java
+++ b/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/unit/domain/entity/DatasourceTest.java
@@ -1,0 +1,43 @@
+package com.pandaterry.schema_microservice.unit.domain.entity;
+
+import com.pandaterry.msa_contracts.enums.schema.DatabaseEngineType;
+import com.pandaterry.msa_contracts.enums.schema.DatabaseType;
+import com.pandaterry.schema_microservice.domain.entity.Datasource;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DatasourceTest {
+
+    @Test
+    void create_메서드가_user와_agent_정보를_저장한다() {
+        // given
+        UUID orgId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID agentId = UUID.randomUUID();
+
+        // when
+        Datasource datasource = Datasource.create(orgId, "test", DatabaseType.RDB, DatabaseEngineType.POSTGRESQL, userId, agentId);
+
+        // then
+        assertThat(datasource.getCreatedByUser()).isEqualTo(userId);
+        assertThat(datasource.getCreatedByAgent()).isEqualTo(agentId);
+    }
+
+    @Test
+    void init_메서드가_user와_agent_정보를_저장한다() {
+        // given
+        UUID orgId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID agentId = UUID.randomUUID();
+
+        // when
+        Datasource datasource = Datasource.init(orgId, userId, agentId);
+
+        // then
+        assertThat(datasource.getCreatedByUser()).isEqualTo(userId);
+        assertThat(datasource.getCreatedByAgent()).isEqualTo(agentId);
+    }
+}


### PR DESCRIPTION
## Summary
- Datasource 생성 시 `createdByUser`, `createdByAgent` 값을 필드에 저장
- 생성자 수정 사항에 대한 단위 테스트 추가