### PR TITLE
헤더 정보 기반 로깅 추가

### DIFF
--- a/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/application/RequestContext.java
+++ b/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/application/RequestContext.java
@@ -1,0 +1,43 @@
+package com.pandaterry.schema_microservice.application;
+
+import java.util.UUID;
+
+/**
+ * Thread-local 컨텍스트에서 요청별 헤더 값을 보관합니다.
+ */
+public class RequestContext {
+    private static final ThreadLocal<RequestContext> HOLDER = new ThreadLocal<>();
+
+    private final UUID orgId;
+    private final UUID userId;
+    private final UUID agentId;
+
+    private RequestContext(UUID orgId, UUID userId, UUID agentId) {
+        this.orgId = orgId;
+        this.userId = userId;
+        this.agentId = agentId;
+    }
+
+    public static void set(UUID orgId, UUID userId, UUID agentId) {
+        HOLDER.set(new RequestContext(orgId, userId, agentId));
+    }
+
+    public static UUID getOrgId() {
+        RequestContext ctx = HOLDER.get();
+        return ctx == null ? null : ctx.orgId;
+    }
+
+    public static UUID getUserId() {
+        RequestContext ctx = HOLDER.get();
+        return ctx == null ? null : ctx.userId;
+    }
+
+    public static UUID getAgentId() {
+        RequestContext ctx = HOLDER.get();
+        return ctx == null ? null : ctx.agentId;
+    }
+
+    public static void clear() {
+        HOLDER.remove();
+    }
+}

--- a/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/presentation/config/WebConfig.java
+++ b/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/presentation/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.pandaterry.schema_microservice.presentation.config;
+
+import com.pandaterry.schema_microservice.presentation.interceptor.MdcLoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final MdcLoggingInterceptor mdcLoggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(mdcLoggingInterceptor);
+    }
+}

--- a/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/presentation/interceptor/MdcLoggingInterceptor.java
+++ b/domains/schema-microservice/src/main/java/com/pandaterry/schema_microservice/presentation/interceptor/MdcLoggingInterceptor.java
@@ -1,0 +1,53 @@
+package com.pandaterry.schema_microservice.presentation.interceptor;
+
+import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.schema_microservice.application.RequestContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.UUID;
+
+/**
+ * 요청 헤더의 조직, 사용자, 에이전트 정보를 MDC와 RequestContext에 저장합니다.
+ */
+@Component
+public class MdcLoggingInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String org = request.getHeader(HeaderKeys.ORG_ID);
+        String user = request.getHeader(HeaderKeys.USER_ID);
+        String agent = request.getHeader(HeaderKeys.AGENT_ID);
+
+        if (org != null) {
+            MDC.put(HeaderKeys.ORG_ID, org);
+        }
+        if (user != null) {
+            MDC.put(HeaderKeys.USER_ID, user);
+        }
+        if (agent != null) {
+            MDC.put(HeaderKeys.AGENT_ID, agent);
+        }
+
+        RequestContext.set(parse(org), parse(user), parse(agent));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        MDC.remove(HeaderKeys.ORG_ID);
+        MDC.remove(HeaderKeys.USER_ID);
+        MDC.remove(HeaderKeys.AGENT_ID);
+        RequestContext.clear();
+    }
+
+    private UUID parse(String value) {
+        try {
+            return value == null ? null : UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/domains/schema-microservice/src/main/resources/logback.xml
+++ b/domains/schema-microservice/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %X{X-Organization-Id} %X{X-User-Id} %X{X-Agent-Id} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/integration/MdcLoggingInterceptorTest.java
+++ b/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/integration/MdcLoggingInterceptorTest.java
@@ -1,0 +1,48 @@
+package com.pandaterry.schema_microservice.integration;
+
+import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.schema_microservice.presentation.config.WebConfig;
+import com.pandaterry.schema_microservice.presentation.interceptor.MdcLoggingInterceptor;
+import com.pandaterry.schema_microservice.integration.support.ContextEchoController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ContextEchoController.class)
+@Import({MdcLoggingInterceptor.class, WebConfig.class})
+class MdcLoggingInterceptorTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void interceptorRegistersAndSetsRequestContext() throws Exception {
+        String org = UUID.randomUUID().toString();
+        String user = UUID.randomUUID().toString();
+        String agent = UUID.randomUUID().toString();
+
+        mockMvc.perform(get("/test/context")
+                        .header(HeaderKeys.ORG_ID, org)
+                        .header(HeaderKeys.USER_ID, user)
+                        .header(HeaderKeys.AGENT_ID, agent))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orgId").value(org))
+                .andExpect(jsonPath("$.userId").value(user))
+                .andExpect(jsonPath("$.agentId").value(agent));
+
+        assertThat(applicationContext.getBeansOfType(MdcLoggingInterceptor.class)).isNotEmpty();
+    }
+}

--- a/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/integration/support/ContextEchoController.java
+++ b/domains/schema-microservice/src/test/java/com/pandaterry/schema_microservice/integration/support/ContextEchoController.java
@@ -1,0 +1,26 @@
+package com.pandaterry.schema_microservice.integration.support;
+
+import com.pandaterry.schema_microservice.application.RequestContext;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+public class ContextEchoController {
+    @GetMapping("/test/context")
+    public Map<String, String> context() {
+        Map<String, String> map = new HashMap<>();
+        if (RequestContext.getOrgId() != null) {
+            map.put("orgId", RequestContext.getOrgId().toString());
+        }
+        if (RequestContext.getUserId() != null) {
+            map.put("userId", RequestContext.getUserId().toString());
+        }
+        if (RequestContext.getAgentId() != null) {
+            map.put("agentId", RequestContext.getAgentId().toString());
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
- 요청 헤더 정보를 저장하는 `RequestContext` 추가
- `MdcLoggingInterceptor`로 헤더 값을 MDC와 Context에 저장
- `WebConfig`에서 인터셉터 등록
- 로그 패턴을 수정하여 orgId/userId/agentId 기록
- 인터셉터 등록 여부를 검증하는 통합 테스트 작성