### PR TITLE
사용량 기록 이벤트 발행 로직 추가

### DIFF
--- a/agent-client/agent-server/src/main/java/com/pandaterry/domain/model/ExecutionJob.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/domain/model/ExecutionJob.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 public record ExecutionJob(
                 UUID jobId,
                 JobStatus status,
+                UUID orgId,
                 String query,
                 LocalDateTime createdAt,
                 LocalDateTime updatedAt) {

--- a/agent-client/agent-server/src/test/java/com/pandaterry/application/service/query/QueryJobProcessorTest.java
+++ b/agent-client/agent-server/src/test/java/com/pandaterry/application/service/query/QueryJobProcessorTest.java
@@ -58,7 +58,7 @@ class QueryJobProcessorTest {
                 UUID jobId = UUID.randomUUID();
                 UUID userId = UUID.randomUUID();
 
-                ExecutionJob job = new ExecutionJob(jobId, JobStatus.PENDING, "select 1",
+                ExecutionJob job = new ExecutionJob(jobId, JobStatus.PENDING, orgId, "select 1",
                         LocalDateTime.now(), LocalDateTime.now());
 
                 when(queryServiceClient.requestQuery(eq(orgId), any(QueryRequest.class)))
@@ -105,7 +105,7 @@ class QueryJobProcessorTest {
                 UUID jobId = UUID.randomUUID();
                 UUID userId = UUID.randomUUID();
 
-                ExecutionJob job = new ExecutionJob(jobId, JobStatus.PENDING, "select 1", LocalDateTime.now(),
+                ExecutionJob job = new ExecutionJob(jobId, JobStatus.PENDING, orgId, "select 1", LocalDateTime.now(),
                                 LocalDateTime.now());
 
                 when(queryServiceClient.requestQuery(eq(orgId), any(QueryRequest.class))).thenReturn(Optional.of(job));

--- a/domains/query-microservice/build.gradle
+++ b/domains/query-microservice/build.gradle
@@ -26,8 +26,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'org.apache.commons:commons-lang3:3.12.0'
+        implementation 'org.springframework.boot:spring-boot-starter-webflux'
+        implementation 'org.springframework.boot:spring-boot-starter-amqp'
+        implementation 'org.apache.commons:commons-lang3:3.12.0'
 	implementation 'com.github.jsqlparser:jsqlparser:4.5'
 	runtimeOnly 'com.h2database:h2'
 

--- a/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/application/service/JobService.java
+++ b/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/application/service/JobService.java
@@ -3,6 +3,9 @@ package com.pandaterry.query_microservice.application.service;
 import com.pandaterry.msa_contracts.dto.query.request.JobResultRequest;
 import com.pandaterry.msa_contracts.enums.query.JobStatus;
 import com.pandaterry.query_microservice.domain.model.ExecutionJob;
+import com.pandaterry.query_microservice.infrastructure.messaging.QuotaUsageProducer;
+import com.pandaterry.msa_contracts.dto.quota.request.QuotaUsageRecordRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -12,12 +15,14 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
+@RequiredArgsConstructor
 public class JobService {
     private final Map<UUID, ExecutionJob> store = new ConcurrentHashMap<>();
+    private final QuotaUsageProducer quotaUsageProducer;
 
-    public Mono<ExecutionJob> createJob(String query) {
+    public Mono<ExecutionJob> createJob(UUID orgId, String query) {
         UUID id = UUID.randomUUID();
-        ExecutionJob job = new ExecutionJob(id, JobStatus.PENDING, query, LocalDateTime.now(), LocalDateTime.now());
+        ExecutionJob job = new ExecutionJob(id, JobStatus.PENDING, orgId, query, LocalDateTime.now(), LocalDateTime.now());
         store.put(id, job);
         return Mono.just(job);
     }
@@ -36,11 +41,20 @@ public class JobService {
             ExecutionJob updated = new ExecutionJob(
                     existing.jobId(),
                     request.status(),
+                    existing.orgId(),
                     existing.query(),
                     existing.createdAt(),
                     LocalDateTime.now()
             );
             store.put(existing.jobId(), updated);
+            if (JobStatus.COMPLETED.equals(request.status())) {
+                quotaUsageProducer.sendQuotaUsage(
+                        QuotaUsageRecordRequest.builder()
+                                .orgId(existing.orgId())
+                                .increment(1L)
+                                .build()
+                );
+            }
         }
         return Mono.empty();
     }

--- a/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/application/service/QueryService.java
+++ b/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/application/service/QueryService.java
@@ -41,7 +41,7 @@ public class QueryService {
 
         public Mono<ExecutionJob> createQueryJob(NaturalLanguageQueryRequest request) {
                 return convertToSQL(request)
-                                .flatMap(jobService::createJob);
+                                .flatMap(sql -> jobService.createJob(request.getOrgId(), sql));
         }
 
 }

--- a/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/domain/model/ExecutionJob.java
+++ b/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/domain/model/ExecutionJob.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 public record ExecutionJob(
         UUID jobId,
         JobStatus status,
+        UUID orgId,
         String query,
         LocalDateTime createdAt,
         LocalDateTime updatedAt

--- a/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/infrastructure/messaging/QuotaUsageProducer.java
+++ b/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/infrastructure/messaging/QuotaUsageProducer.java
@@ -1,0 +1,7 @@
+package com.pandaterry.query_microservice.infrastructure.messaging;
+
+import com.pandaterry.msa_contracts.dto.quota.request.QuotaUsageRecordRequest;
+
+public interface QuotaUsageProducer {
+    void sendQuotaUsage(QuotaUsageRecordRequest request);
+}

--- a/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/infrastructure/messaging/RabbitQuotaUsageProducer.java
+++ b/domains/query-microservice/src/main/java/com/pandaterry/query_microservice/infrastructure/messaging/RabbitQuotaUsageProducer.java
@@ -1,0 +1,22 @@
+package com.pandaterry.query_microservice.infrastructure.messaging;
+
+import com.pandaterry.msa_contracts.dto.quota.request.QuotaUsageRecordRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RabbitQuotaUsageProducer implements QuotaUsageProducer {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${quota.usage.queue:quota-usage}")
+    private String queue;
+
+    @Override
+    public void sendQuotaUsage(QuotaUsageRecordRequest request) {
+        rabbitTemplate.convertAndSend(queue, request);
+    }
+}

--- a/domains/query-microservice/src/main/resources/application.yml
+++ b/domains/query-microservice/src/main/resources/application.yml
@@ -5,3 +5,7 @@ spring:
 schema:
   service:
     url: ${SCHEMA_SERVICE_URL:http://localhost:8081}
+
+quota:
+  usage:
+    queue: quota-usage

--- a/domains/query-microservice/src/test/java/com/pandaterry/query_microservice/unit/application/service/JobServiceTest.java
+++ b/domains/query-microservice/src/test/java/com/pandaterry/query_microservice/unit/application/service/JobServiceTest.java
@@ -4,6 +4,8 @@ import com.pandaterry.msa_contracts.dto.query.request.JobResultRequest;
 import com.pandaterry.msa_contracts.enums.query.JobStatus;
 import com.pandaterry.query_microservice.application.service.JobService;
 import com.pandaterry.query_microservice.domain.model.ExecutionJob;
+import com.pandaterry.query_microservice.infrastructure.messaging.QuotaUsageProducer;
+import com.pandaterry.msa_contracts.dto.quota.request.QuotaUsageRecordRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,15 +16,17 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class JobServiceTest {
     private JobService jobService;
+    private DummyProducer producer;
 
     @BeforeEach
     void setUp() {
-        jobService = new JobService();
+        producer = new DummyProducer();
+        jobService = new JobService(producer);
     }
 
     @Test
     void create_and_poll_job() {
-        ExecutionJob created = jobService.createJob("select 1").block();
+        ExecutionJob created = jobService.createJob(UUID.randomUUID(), "select 1").block();
         assertNotNull(created);
         ExecutionJob polled = jobService.pollPendingJob(UUID.randomUUID()).block();
         assertEquals(created.jobId(), polled.jobId());
@@ -30,10 +34,17 @@ class JobServiceTest {
 
     @Test
     void report_result_updates_status() {
-        ExecutionJob created = jobService.createJob("select 1").block();
+        ExecutionJob created = jobService.createJob(UUID.randomUUID(), "select 1").block();
         jobService.reportResult(created.jobId(),
                 new JobResultRequest(created.jobId(), JobStatus.COMPLETED, "ok", null)).block();
         ExecutionJob updated = jobService.getJob(created.jobId()).block();
         assertEquals(JobStatus.COMPLETED, updated.status());
+    }
+
+    static class DummyProducer implements QuotaUsageProducer {
+        @Override
+        public void sendQuotaUsage(QuotaUsageRecordRequest request) {
+            // no-op for tests
+        }
     }
 }

--- a/shared/msa-contracts/src/main/java/com/pandaterry/msa_contracts/constants/ApiPath.java
+++ b/shared/msa-contracts/src/main/java/com/pandaterry/msa_contracts/constants/ApiPath.java
@@ -60,7 +60,7 @@ public final class ApiPath {
         public static final String EXECUTE = BASE + EXECUTE_SUFFIX;
     }
 
-버    public static final class Job {
+    public static final class Job {
         public static final String BASE = "/jobs";
 
         // 특정 작업


### PR DESCRIPTION
## Summary
- 작업 결과 업데이트 시 조직 ID를 포함하도록 ExecutionJob 개선
- RabbitMQ 기반 QuotaUsageProducer 작성 및 적용
- JobService에서 완료 시 사용량 기록 이벤트 전송
- 이에 따른 테스트 및 설정 수정