### PR TITLE
파일 다운로드 다형성 개선

### DIFF
--- a/agent-client/agent-server/build.gradle
+++ b/agent-client/agent-server/build.gradle
@@ -80,13 +80,11 @@ tasks.named("dockerfileNative") {
     jdkVersion = "17"
 }
 
-test{
-    // PR(CI) 모드: 프로젝트 실행 시 -Pci 옵션이 있으면 실행
+test {
+    useJUnitPlatform()
     if (project.hasProperty('ci')) {
-        filter {
-            // JUnit Jupiter 엔진만 사용
+        useJUnitPlatform {
             includeEngines 'junit-jupiter'
-            // "TestContainer" 태그가 붙은 테스트는 모두 제외
             excludeTags 'Docker'
         }
     }

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/DownloadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/DownloadClient.java
@@ -1,0 +1,13 @@
+package com.pandaterry.infrastructure.client;
+
+import java.io.InputStream;
+
+/**
+ * 파일 다운로드를 담당하는 클라이언트 인터페이스.
+ */
+public interface DownloadClient {
+    /**
+     * 지정한 URL에서 파일을 다운로드한다.
+     */
+    InputStream download(String url) throws Exception;
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/LocalDownloadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/LocalDownloadClient.java
@@ -1,0 +1,23 @@
+package com.pandaterry.infrastructure.client;
+
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.net.URI;
+
+/**
+ * 로컬 파일 시스템에서 파일을 읽어오는 구현체.
+ */
+@Requires(property = "storage.type", value = "local")
+@Singleton
+public class LocalDownloadClient implements DownloadClient {
+
+    @Override
+    public InputStream download(String url) throws Exception {
+        Path path = Path.of(URI.create(url));
+        return Files.newInputStream(path);
+    }
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/PresignedUrlDownloadClient.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/infrastructure/client/PresignedUrlDownloadClient.java
@@ -1,0 +1,36 @@
+package com.pandaterry.infrastructure.client;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import jakarta.inject.Singleton;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+
+/**
+ * 프리사인 URL을 이용해 파일을 다운로드하는 구현체.
+ */
+@Requires(property = "storage.type", value = "s3")
+@Singleton
+public class PresignedUrlDownloadClient implements DownloadClient {
+
+    private final HttpClient httpClient;
+
+    public PresignedUrlDownloadClient(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public InputStream download(String url) throws Exception {
+        URI uri = URI.create(url);
+        try {
+            byte[] data = httpClient.toBlocking().retrieve(HttpRequest.GET(uri), byte[].class);
+            return new ByteArrayInputStream(data);
+        } catch (HttpClientResponseException e) {
+            throw new RuntimeException("Failed to download file: " + e.getMessage(), e);
+        }
+    }
+}

--- a/agent-client/agent-server/src/main/java/com/pandaterry/presentation/controller/QueryController.java
+++ b/agent-client/agent-server/src/main/java/com/pandaterry/presentation/controller/QueryController.java
@@ -1,12 +1,15 @@
 package com.pandaterry.presentation.controller;
 
 import com.pandaterry.application.facade.QueryJobProcessFacade;
+import com.pandaterry.infrastructure.client.DownloadClient;
 import com.pandaterry.msa_contracts.constants.ApiPath;
 import com.pandaterry.msa_contracts.dto.query.request.NaturalLanguageQueryRequest;
 import com.pandaterry.msa_contracts.dto.query.response.NaturalLanguageQueryResponse;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.server.types.files.StreamedFile;
 import jakarta.inject.Inject;
 
 @Controller("/api/v1/" + ApiPath.Query.BASE)
@@ -15,8 +18,21 @@ public class QueryController {
     @Inject
     private QueryJobProcessFacade queryJobProcessFacade;
 
+    @Inject
+    private DownloadClient downloadClient;
+
     @Post(ApiPath.Query.EXECUTE_SUFFIX)
     public HttpResponse<NaturalLanguageQueryResponse> executeNaturalLanguageQuery(NaturalLanguageQueryRequest request){
         return HttpResponse.ok(queryJobProcessFacade.handleQuery(request));
+    }
+
+    @Post(ApiPath.Query.EXECUTE_SUFFIX + "/download")
+    public HttpResponse<StreamedFile> downloadExcel(NaturalLanguageQueryRequest request) throws Exception {
+        NaturalLanguageQueryResponse res = queryJobProcessFacade.handleQuery(request);
+        StreamedFile file = new StreamedFile(
+                downloadClient.download(res.downloadUrl()),
+                MediaType.of("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        ).attach(res.filename());
+        return HttpResponse.ok(file);
     }
 }

--- a/agent-client/agent-server/src/test/java/com/pandaterry/infrastructure/client/LocalDownloadClientTest.java
+++ b/agent-client/agent-server/src/test/java/com/pandaterry/infrastructure/client/LocalDownloadClientTest.java
@@ -1,0 +1,26 @@
+package com.pandaterry.infrastructure.client;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalDownloadClientTest {
+
+    private final LocalDownloadClient client = new LocalDownloadClient();
+
+    @Test
+    void fileSchemeDownload() throws Exception {
+        Path temp = Files.createTempFile("sample", ".txt");
+        Files.writeString(temp, "hello", StandardCharsets.UTF_8);
+
+        try (InputStream is = client.download(temp.toUri().toString())) {
+            String result = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(result).isEqualTo("hello");
+        }
+    }
+}

--- a/shared/msa-contracts/src/main/java/com/pandaterry/msa_contracts/constants/ApiPath.java
+++ b/shared/msa-contracts/src/main/java/com/pandaterry/msa_contracts/constants/ApiPath.java
@@ -60,7 +60,7 @@ public final class ApiPath {
         public static final String EXECUTE = BASE + EXECUTE_SUFFIX;
     }
 
-버    public static final class Job {
+    public static final class Job {
         public static final String BASE = "/jobs";
 
         // 특정 작업


### PR DESCRIPTION
## Summary
- 파일 다운로드 클라이언트를 인터페이스 기반으로 분리
- 로컬 및 프리사인 URL 방식 구현체 추가
- 컨트롤러에서 새 클라이언트 사용하도록 수정
- 기존 테스트 파일을 LocalDownloadClientTest로 교체
