### PR TITLE
에이전트 인증 필터 구현

### DIFF
--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/config/SecurityConfig.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.pandaterry.gateway.shared.converters.CustomJwtAuthenticationConverter;
+import com.pandaterry.gateway.shared.filters.AgentAuthenticationFilter;
 import com.pandaterry.gateway.shared.filters.JwtAuthenticationFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
@@ -29,8 +31,10 @@ public class SecurityConfig {
 
     @Bean
     public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http,
-                                                            JwtAuthenticationFilter jwtAuthenticationFilter) {
+                                                            JwtAuthenticationFilter jwtAuthenticationFilter,
+                                                            AgentAuthenticationFilter agentAuthenticationFilter) {
         http.csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .addFilterAt(agentAuthenticationFilter, SecurityWebFiltersOrder.FIRST)
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/actuator/**").permitAll()
                         .pathMatchers("/api/auth/**").permitAll()  // 인증 엔드포인트는 허용

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilter.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.pandaterry.gateway.shared.filters;
+
+import com.pandaterry.gateway.shared.service.AgentAuthService;
+import com.pandaterry.gateway.shared.service.AgentInfo;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class AgentAuthenticationFilter implements WebFilter {
+
+    private static final String SECRET_HEADER = "X-AGENT-SECRET";
+    private final AgentAuthService agentAuthService;
+
+    public AgentAuthenticationFilter(AgentAuthService agentAuthService) {
+        this.agentAuthService = agentAuthService;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String secret = exchange.getRequest().getHeaders().getFirst(SECRET_HEADER);
+        if (secret == null) {
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        AgentInfo info = agentAuthService.authenticate(secret);
+        if (info == null) {
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        var mutatedRequest = exchange.getRequest().mutate()
+                .headers(headers -> {
+                    headers.remove(SECRET_HEADER);
+                    headers.add("X-Agent-Id", info.agentId());
+                    headers.add("X-Org-Id", info.orgId());
+                    headers.add("X-Roles", "AGENT");
+                    headers.add("X-Internal-Request", "true");
+                })
+                .build();
+
+        ServerWebExchange mutatedExchange = exchange.mutate().request(mutatedRequest).build();
+        return chain.filter(mutatedExchange);
+    }
+}

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/service/AgentAuthService.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/service/AgentAuthService.java
@@ -1,0 +1,18 @@
+package com.pandaterry.gateway.shared.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class AgentAuthService {
+
+    private static final Map<String, AgentInfo> SECRET_STORE = Map.of(
+            "secret1", new AgentInfo("agent1", "org1"),
+            "secret2", new AgentInfo("agent2", "org2")
+    );
+
+    public AgentInfo authenticate(String secret) {
+        return SECRET_STORE.get(secret);
+    }
+}

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/service/AgentInfo.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/service/AgentInfo.java
@@ -1,0 +1,6 @@
+package com.pandaterry.gateway.shared.service;
+
+/**
+ * agentId와 orgId 정보를 담는 레코드
+ */
+public record AgentInfo(String agentId, String orgId) {}

--- a/backend/infrastructure/gateway/src/test/java/com/pandaterry/gateway/shared/config/SecurityConfigTest.java
+++ b/backend/infrastructure/gateway/src/test/java/com/pandaterry/gateway/shared/config/SecurityConfigTest.java
@@ -1,7 +1,9 @@
 package com.pandaterry.gateway.shared.config;
 
 import com.pandaterry.gateway.presentation.TestController;
+import com.pandaterry.gateway.shared.filters.AgentAuthenticationFilter;
 import com.pandaterry.gateway.shared.filters.JwtAuthenticationFilter;
+import com.pandaterry.gateway.shared.service.AgentAuthService;
 import com.pandaterry.gateway.shared.utils.JwtUtil;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -22,7 +24,9 @@ import java.util.List;
 
 @WebFluxTest(controllers = TestController.class)
 @Import({SecurityConfig.class, JwtAuthenticationConverter.class, JwtUtil.class,
-        JwtAuthenticationFilter.class  // 필터 추가
+        JwtAuthenticationFilter.class,
+        AgentAuthenticationFilter.class,
+        AgentAuthService.class
 })
 @TestPropertySource(properties = {
         "spring.cloud.config.enabled=false",

--- a/backend/infrastructure/gateway/src/test/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilterTest.java
+++ b/backend/infrastructure/gateway/src/test/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilterTest.java
@@ -1,0 +1,48 @@
+package com.pandaterry.gateway.shared.filters;
+
+import com.pandaterry.gateway.shared.service.AgentAuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+class AgentAuthenticationFilterTest {
+
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp() {
+        AgentAuthService authService = new AgentAuthService();
+        webTestClient = WebTestClient.bindToWebHandler(exchange -> Mono.empty())
+                .webFilter(new AgentAuthenticationFilter(authService))
+                .configureClient()
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효한 시크릿이면 요청이 통과되어야 한다")
+    void whenValidSecret_thenPass() {
+        webTestClient.get()
+                .header("X-AGENT-SECRET", "secret1")
+                .exchange()
+                .expectStatus().isOk();
+    }
+
+    @Test
+    @DisplayName("시크릿이 없으면 401을 반환해야 한다")
+    void whenNoSecret_thenUnauthorized() {
+        webTestClient.get()
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    @DisplayName("잘못된 시크릿이면 401을 반환해야 한다")
+    void whenInvalidSecret_thenUnauthorized() {
+        webTestClient.get()
+                .header("X-AGENT-SECRET", "wrong")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+}


### PR DESCRIPTION
## Summary
- AgentAuthService로 시크릿을 검증해 Agent 정보를 반환
- AgentAuthenticationFilter에서 `X-AGENT-SECRET`을 검사하고 성공 시 헤더 주입
- SecurityConfig에서 필터를 체인 앞단에 등록
- 관련 단위 테스트 작성