### PR TITLE
JDK 17 환경 명시 및 toolchain 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ nl2sql-studio/
 
 ### 1. 사전 요구사항
 
-* Java 11 이상
+* Java 17 이상
+  - Ubuntu 기준 설치 예시: `sudo apt-get install openjdk-17-jdk`
 * Node.js 16 이상 (프론트엔드 빌드용)
 * 각 DB에 대한 JDBC 드라이버 (MySQL, PostgreSQL, Oracle)
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,10 @@
 # NL2SQL Excel Exporter
 > natural language to SQL and generating EXCEL from it.
 
+## 개발 환경
+
+* JDK 17 이상 (Ubuntu 예시: `sudo apt-get install openjdk-17-jdk`)
+
 ## 서비스별 역할
 
 | 구성 요소 | 주요 역할 | 통신 방식 | 비고 |

--- a/backend/agent-studio/agent-studio-server/build.gradle
+++ b/backend/agent-studio/agent-studio-server/build.gradle
@@ -51,8 +51,10 @@ application {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion("17")
-    targetCompatibility = JavaVersion.toVersion("17")
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
 }
 
 graalvmNative.toolchainDetection = false

--- a/backend/domains/query-microservice/build.gradle
+++ b/backend/domains/query-microservice/build.gradle
@@ -8,7 +8,10 @@ group = 'com.pandaterry'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+        toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+                vendor = JvmVendorSpec.ADOPTIUM
+        }
 }
 
 configurations {

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.installations.auto-download=true

--- a/backend/shared/msa-contracts/build.gradle
+++ b/backend/shared/msa-contracts/build.gradle
@@ -6,8 +6,10 @@ group = 'com.pandaterry.msa-contracts'
 version = '1.0.0'
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+        vendor = JvmVendorSpec.ADOPTIUM
+    }
 }
 
 repositories {


### PR DESCRIPTION
## Summary
- README에 JDK 17 요구사항과 설치 예시 추가
- 백엔드 README에 개발 환경 섹션 추가
- 각 모듈 빌드 스크립트에 JDK 17 toolchain 설정 및 자동 다운로드 옵션 추가
- backend/gradle.properties에 자동 다운로드 설정