### PR TITLE
게이트웨이에서 인증 서비스 연동 수정

### DIFF
--- a/backend/infrastructure/gateway/build.gradle
+++ b/backend/infrastructure/gateway/build.gradle
@@ -38,8 +38,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
-	implementation 'io.jsonwebtoken:jjwt:0.12.6'
+        implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+        implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+        implementation 'io.jsonwebtoken:jjwt:0.12.6'
 	// OAuth2 Resource Server (JWT 검증)
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/GatewayApplication.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/GatewayApplication.java
@@ -2,8 +2,10 @@ package com.pandaterry.gateway;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class GatewayApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(GatewayApplication.class, args);

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/infrastructure/client/AuthServiceClient.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/infrastructure/client/AuthServiceClient.java
@@ -1,0 +1,24 @@
+package com.pandaterry.gateway.infrastructure.client;
+
+import com.pandaterry.msa_contracts.constants.ApiPath;
+import com.pandaterry.msa_contracts.dto.auth.request.SignupRequest;
+import com.pandaterry.msa_contracts.dto.auth.request.LoginRequest;
+import com.pandaterry.msa_contracts.dto.auth.response.TokenResponse;
+import com.pandaterry.msa_contracts.dto.auth.response.UserInfoResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "auth-service", url = "${auth-service.base-url}", path = "/api/v1")
+public interface AuthServiceClient {
+    @PostMapping(ApiPath.Auth.SIGNUP)
+    Void signup(@RequestBody SignupRequest request);
+
+    @PostMapping(ApiPath.Auth.LOGIN)
+    TokenResponse login(@RequestBody LoginRequest request);
+
+    @GetMapping(ApiPath.Auth.ME)
+    UserInfoResponse me(@RequestHeader("X-User-Id") String userId);
+}

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/presentation/AuthController.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/presentation/AuthController.java
@@ -1,0 +1,34 @@
+package com.pandaterry.gateway.presentation;
+
+import com.pandaterry.gateway.infrastructure.client.AuthServiceClient;
+import com.pandaterry.msa_contracts.constants.ApiPath;
+import com.pandaterry.msa_contracts.dto.auth.request.LoginRequest;
+import com.pandaterry.msa_contracts.dto.auth.request.SignupRequest;
+import com.pandaterry.msa_contracts.dto.auth.response.TokenResponse;
+import com.pandaterry.msa_contracts.dto.auth.response.UserInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1" + ApiPath.Auth.BASE)
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthServiceClient authServiceClient;
+
+    @PostMapping(ApiPath.Auth.SIGNUP_SUFFIX)
+    public ResponseEntity<Void> signup(@RequestBody SignupRequest request) {
+        authServiceClient.signup(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping(ApiPath.Auth.LOGIN_SUFFIX)
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        return ResponseEntity.ok(authServiceClient.login(request));
+    }
+
+    @GetMapping(ApiPath.Auth.ME_SUFFIX)
+    public ResponseEntity<UserInfoResponse> me(@RequestHeader("X-User-Id") String userId) {
+        return ResponseEntity.ok(authServiceClient.me(userId));
+    }
+}

--- a/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilter.java
+++ b/backend/infrastructure/gateway/src/main/java/com/pandaterry/gateway/shared/filters/AgentAuthenticationFilter.java
@@ -24,9 +24,9 @@ public class AgentAuthenticationFilter implements WebFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
         String secret = exchange.getRequest().getHeaders().getFirst(HeaderKeys.AGENT_SECRET);
+        // 에이전트가 아닌 일반 요청의 경우 필터를 통과시킨다
         if (secret == null) {
-            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-            return exchange.getResponse().setComplete();
+            return chain.filter(exchange);
         }
 
         AgentInfo info = agentAuthService.authenticate(secret);

--- a/backend/infrastructure/gateway/src/main/resources/application.yml
+++ b/backend/infrastructure/gateway/src/main/resources/application.yml
@@ -6,3 +6,11 @@ spring:
     name: gateway
   profiles:
     active: local
+
+auth-service:
+  base-url: http://localhost:8081
+
+jwt:
+  secret: 01234567890123456789012345678901
+  header: Authorization
+  prefix: Bearer


### PR DESCRIPTION
## 요약
- 에이전트 인증 필터가 일반 요청까지 차단하던 문제 수정
- Feign 클라이언트 추가 및 `@EnableFeignClients` 활성화
- 인증 API 위임용 컨트롤러 구현
- 로컬 실행을 위한 기본 설정 추가