### PR TITLE
서비스 클라이언트 경로 정비 및 테스트 추가

### DIFF
--- a/backend/agent-studio/agent-studio-server/build.gradle
+++ b/backend/agent-studio/agent-studio-server/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core:5.11.0")
     testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
     testImplementation("org.assertj:assertj-core:3.25.3")
+    testImplementation 'com.github.tomakehurst:wiremock-standalone:3.0.1'
 }
 
 application {

--- a/backend/agent-studio/agent-studio-server/src/main/java/com/pandaterry/infrastructure/client/QueryServiceClient.java
+++ b/backend/agent-studio/agent-studio-server/src/main/java/com/pandaterry/infrastructure/client/QueryServiceClient.java
@@ -2,6 +2,7 @@ package com.pandaterry.infrastructure.client;
 
 import com.pandaterry.domain.model.ExecutionJob;
 import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.msa_contracts.constants.RoutePath;
 import com.pandaterry.msa_contracts.dto.query.request.JobResultRequest;
 import com.pandaterry.presentation.dto.request.QueryRequest;
 import io.micronaut.http.client.HttpClient;
@@ -17,6 +18,8 @@ import java.util.UUID;
 public class QueryServiceClient extends BaseServiceClient {
     private static final Logger logger = LoggerFactory.getLogger(QueryServiceClient.class);
 
+    private static final String PREFIX = "/api/v1";
+
     public QueryServiceClient(HttpClient httpClient, String baseUrl, String agentSecret) {
         super(httpClient, baseUrl, agentSecret);
     }
@@ -25,7 +28,7 @@ public class QueryServiceClient extends BaseServiceClient {
     public Optional<ExecutionJob> requestQuery(UUID orgId, QueryRequest payload) {
         try {
             Map<String, String> headers = Map.of(HeaderKeys.ORG_ID, orgId.toString());
-            ExecutionJob job = post("/api/v1/queries", payload, headers, ExecutionJob.class);
+            ExecutionJob job = post(RoutePath.Query.BASE, payload, headers, ExecutionJob.class);
             return Optional.ofNullable(job);
         } catch (Exception e) {
             logger.error("Failed to request query", e);
@@ -36,7 +39,7 @@ public class QueryServiceClient extends BaseServiceClient {
     // 1. 작업 Polling
     public Optional<ExecutionJob> pollPendingJob(UUID agentId) {
         try {
-            String path = "/jobs?agentId=" + agentId + "&status=PENDING";
+            String path = PREFIX + "/jobs?agentId=" + agentId + "&status=PENDING";
             ExecutionJob job = get(path, ExecutionJob.class);
             return Optional.ofNullable(job);
         } catch (Exception e) {
@@ -47,7 +50,7 @@ public class QueryServiceClient extends BaseServiceClient {
 
     // 2. 작업 결과 보고
     public void reportJobResult(UUID jobId, JobResultRequest payload) {
-        String path = "/jobs/" + jobId + "/result";
+        String path = PREFIX + "/jobs/" + jobId + "/result";
         post(path, payload, null);
     }
 

--- a/backend/agent-studio/agent-studio-server/src/main/java/com/pandaterry/infrastructure/client/SchemaServiceClient.java
+++ b/backend/agent-studio/agent-studio-server/src/main/java/com/pandaterry/infrastructure/client/SchemaServiceClient.java
@@ -1,6 +1,7 @@
 package com.pandaterry.infrastructure.client;
 
 import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.msa_contracts.constants.RoutePath;
 import com.pandaterry.msa_contracts.dto.schema.request.RegisterSchemaRequest;
 import com.pandaterry.msa_contracts.dto.schema.response.RegisterSchemaResponse;
 import io.micronaut.http.client.HttpClient;
@@ -22,6 +23,6 @@ public class SchemaServiceClient extends BaseServiceClient {
         header.put(HeaderKeys.USER_ID, req.userId().toString());
         header.put(HeaderKeys.AGENT_ID, req.agentId().toString());
 
-        return post("/schemas", req, header, null);
+        return post(RoutePath.Schema.BASE, req, header, null);
     }
 }

--- a/backend/agent-studio/agent-studio-server/src/test/java/com/pandaterry/infrastructure/client/QueryServiceClientTest.java
+++ b/backend/agent-studio/agent-studio-server/src/test/java/com/pandaterry/infrastructure/client/QueryServiceClientTest.java
@@ -1,0 +1,67 @@
+import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.infrastructure.client.QueryServiceClient;
+import com.pandaterry.msa_contracts.enums.query.JobStatus;
+import com.pandaterry.msa_contracts.dto.query.request.JobResultRequest;
+import com.pandaterry.presentation.dto.request.QueryRequest;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class QueryServiceClientTest {
+
+    @Test
+    void requestQuery_호출경로검증() {
+        HttpClient httpClient = mock(HttpClient.class);
+        BlockingHttpClient blocking = mock(BlockingHttpClient.class);
+        when(httpClient.toBlocking()).thenReturn(blocking);
+        when(blocking.retrieve(any(MutableHttpRequest.class), any(Class.class))).thenReturn(null);
+        when(blocking.exchange(any(MutableHttpRequest.class))).thenReturn(null);
+
+        QueryServiceClient client = new QueryServiceClient(httpClient, "http://localhost", "secret");
+        UUID orgId = UUID.randomUUID();
+
+        client.requestQuery(orgId, new QueryRequest("q"));
+
+        ArgumentCaptor<MutableHttpRequest> captor = ArgumentCaptor.forClass(MutableHttpRequest.class);
+        verify(blocking).retrieve(captor.capture(), any(Class.class));
+        MutableHttpRequest req = captor.getValue();
+        assertThat(req.getUri().getPath()).isEqualTo("/api/v1/queries");
+        assertThat(req.getHeaders().get(HeaderKeys.ORG_ID)).isEqualTo(orgId.toString());
+    }
+
+    @Test
+    void pollAndReport_호출경로검증() {
+        HttpClient httpClient = mock(HttpClient.class);
+        BlockingHttpClient blocking = mock(BlockingHttpClient.class);
+        when(httpClient.toBlocking()).thenReturn(blocking);
+        when(blocking.retrieve(any(MutableHttpRequest.class), any(Class.class))).thenReturn(null);
+
+        QueryServiceClient client = new QueryServiceClient(httpClient, "http://localhost", "secret");
+        UUID agentId = UUID.randomUUID();
+        UUID jobId = UUID.randomUUID();
+
+        client.pollPendingJob(agentId);
+        client.reportJobResult(jobId, new JobResultRequest(jobId, JobStatus.COMPLETED, "url", null));
+
+        ArgumentCaptor<MutableHttpRequest> captor = ArgumentCaptor.forClass(MutableHttpRequest.class);
+        verify(blocking).retrieve(captor.capture(), any(Class.class));
+        MutableHttpRequest req1 = captor.getValue();
+        assertThat(req1.getUri().getPath()).isEqualTo("/api/v1/jobs");
+        assertThat(req1.getUri().getQuery()).isEqualTo("agentId=" + agentId + "&status=PENDING");
+
+        ArgumentCaptor<MutableHttpRequest> captor2 = ArgumentCaptor.forClass(MutableHttpRequest.class);
+        verify(blocking).exchange(captor2.capture());
+        MutableHttpRequest req2 = captor2.getValue();
+        assertThat(req2.getUri().getPath()).isEqualTo("/api/v1/jobs/" + jobId + "/result");
+    }
+}

--- a/backend/agent-studio/agent-studio-server/src/test/java/com/pandaterry/infrastructure/client/SchemaServiceClientTest.java
+++ b/backend/agent-studio/agent-studio-server/src/test/java/com/pandaterry/infrastructure/client/SchemaServiceClientTest.java
@@ -1,0 +1,46 @@
+import com.pandaterry.msa_contracts.constants.HeaderKeys;
+import com.pandaterry.msa_contracts.dto.schema.request.RegisterSchemaRequest;
+import com.pandaterry.msa_contracts.vo.schema.TableSchema;
+import com.pandaterry.infrastructure.client.SchemaServiceClient;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class SchemaServiceClientTest {
+
+    @Test
+    void uploadSchema_호출경로검증() {
+        HttpClient httpClient = mock(HttpClient.class);
+        BlockingHttpClient blocking = mock(BlockingHttpClient.class);
+        when(httpClient.toBlocking()).thenReturn(blocking);
+        when(blocking.exchange(any(MutableHttpRequest.class))).thenReturn(null);
+
+        SchemaServiceClient client = new SchemaServiceClient(httpClient, "http://localhost", "secret");
+
+        UUID orgId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID agentId = UUID.randomUUID();
+        UUID dsId = UUID.randomUUID();
+
+        RegisterSchemaRequest req = new RegisterSchemaRequest(orgId, userId, agentId, dsId, "ds", List.of(), "raw");
+        client.uploadSchema(req);
+
+        ArgumentCaptor<MutableHttpRequest> captor = ArgumentCaptor.forClass(MutableHttpRequest.class);
+        verify(blocking).exchange(captor.capture());
+        MutableHttpRequest r = captor.getValue();
+        assertThat(r.getUri().getPath()).isEqualTo("/api/v1/schemas");
+        assertThat(r.getHeaders().get(HeaderKeys.ORG_ID)).isEqualTo(orgId.toString());
+        assertThat(r.getHeaders().get(HeaderKeys.USER_ID)).isEqualTo(userId.toString());
+        assertThat(r.getHeaders().get(HeaderKeys.AGENT_ID)).isEqualTo(agentId.toString());
+    }
+}


### PR DESCRIPTION
## Summary
- 서비스 클라이언트가 실제 마이크로서비스 경로와 동일하도록 수정
- QueryServiceClient와 SchemaServiceClient에 대한 단위 테스트 작성
- WireMock 대신 Mockito로 HTTP 요청 검증