### PR TITLE
데이터소스 상세 페이지 및 스키마 업로드 연동

### DIFF
--- a/frontend/agent_studio_desktop/src/App.tsx
+++ b/frontend/agent_studio_desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { PublicOnlyRoute } from "@/components/auth/PublicOnlyRoute";
 import { Login } from "@/components/pages/Login";
 import { Signup } from "@/components/pages/Signup";
 import { Datasources } from "@/components/pages/Datasources";
+import { DatasourceDetail } from "@/components/pages/DatasourceDetail";
 import { Me } from "@/components/pages/Me";
 import NotFound from "@/components/pages/NotFound";
 import { RootRedirect } from "@/components/auth/RootRedirect";
@@ -38,6 +39,14 @@ const App: React.FC = () => {
           element={
             <ProtectedRoute>
               <Datasources />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/datasources/:datasourceId"
+          element={
+            <ProtectedRoute>
+              <DatasourceDetail />
             </ProtectedRoute>
           }
         />

--- a/frontend/agent_studio_desktop/src/components/pages/DatasourceDetail.tsx
+++ b/frontend/agent_studio_desktop/src/components/pages/DatasourceDetail.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  schemaClient,
+  Datasource,
+  ScanSchemaResponse,
+  RegisterSchemaRequest,
+} from "@/lib/api/schemaClient";
+import { useAuth } from "@/hooks/useAuth";
+import { useAuthStore } from "@/stores/authStore";
+
+const Container = styled.div`
+  padding: 2rem;
+`;
+
+export const DatasourceDetail: React.FC = () => {
+  const { datasourceId } = useParams<{ datasourceId: string }>();
+  const { accessToken } = useAuth();
+  const { userId, userInfo } = useAuthStore();
+  const [datasource, setDatasource] = useState<Datasource | null>(null);
+  const [scanResult, setScanResult] = useState<ScanSchemaResponse | null>(null);
+  const [schemaName, setSchemaName] = useState("");
+
+  useEffect(() => {
+    if (!datasourceId) return;
+    const fetch = async () => {
+      try {
+        const ds = await schemaClient.getDatasource(accessToken!, datasourceId);
+        setDatasource(ds);
+        setSchemaName(ds.name ?? "");
+      } catch (e) {
+        console.error("데이터소스 조회 실패:", e);
+      }
+    };
+    fetch();
+  }, [datasourceId, accessToken]);
+
+  const handleScan = async () => {
+    if (!datasourceId) return;
+    try {
+      const result = await schemaClient.scanSchema(accessToken!, datasourceId);
+      setScanResult(result);
+    } catch (e) {
+      console.error("스키마 스캔 실패:", e);
+      alert("스키마 스캔 중 오류가 발생했습니다.");
+    }
+  };
+
+  const handleRegister = async () => {
+    if (!scanResult || !userInfo) return;
+    const req: RegisterSchemaRequest = {
+      orgId: userInfo.organization.id,
+      userId: userId!,
+      agentId: (import.meta.env.VITE_AGENT_ID as string) || "agent",
+      datasourceId: scanResult.datasourceId,
+      name: schemaName || "schema",
+      schemas: scanResult.schemas,
+      rawSchema: scanResult.rawSchema,
+    };
+    try {
+      await schemaClient.registerSchema(accessToken!, req);
+      alert("스키마가 등록되었습니다.");
+    } catch (e) {
+      console.error("스키마 등록 실패:", e);
+      alert("스키마 등록 중 오류가 발생했습니다.");
+    }
+  };
+
+  return (
+    <Container>
+      {datasource && (
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle>{datasource.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p>DB Type: {datasource.dbType}</p>
+            <p>Engine: {datasource.engineType}</p>
+          </CardContent>
+        </Card>
+      )}
+      <div className="flex gap-2 mb-4">
+        <Button onClick={handleScan}>스키마 스캔</Button>
+        {scanResult && (
+          <>
+            <Input
+              placeholder="스키마 이름"
+              value={schemaName}
+              onChange={(e) => setSchemaName(e.target.value)}
+              className="w-48"
+            />
+            <Button onClick={handleRegister}>스키마 업로드</Button>
+          </>
+        )}
+      </div>
+      {scanResult && (
+        <div className="space-y-4">
+          {scanResult.schemas.map((table) => (
+            <Card key={table.id}>
+              <CardHeader>
+                <CardTitle>{table.tableName}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="list-disc pl-4">
+                  {table.columns.map((col) => (
+                    <li key={col.id}>{`${col.columnName} (${col.dataType})`}</li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </Container>
+  );
+};

--- a/frontend/agent_studio_desktop/src/lib/api/constants/headers.ts
+++ b/frontend/agent_studio_desktop/src/lib/api/constants/headers.ts
@@ -2,6 +2,9 @@ export const HEADERS = {
   CONTENT_TYPE: "Content-Type",
   AUTHORIZATION: "Authorization",
   X_REFRESH_TOKEN: "X-Refresh-Token",
+  ORG_ID: "X-Organization-Id",
+  USER_ID: "X-User-Id",
+  AGENT_ID: "X-Agent-Id",
 } as const;
 
 export const CONTENT_TYPES = {

--- a/frontend/agent_studio_desktop/src/lib/api/index.ts
+++ b/frontend/agent_studio_desktop/src/lib/api/index.ts
@@ -1,13 +1,15 @@
 import apiClient from "@/lib/api/client";
 import { authInterceptor } from "@/lib/api/interceptors/authInterceptor";
+import { contextInterceptor } from "@/lib/api/interceptors/contextInterceptor";
 import { AxiosInstance } from "axios";
 
 // 인증 인터셉터 설정
-setupAuthInterceptors(apiClient);
+setupInterceptors(apiClient);
 
 export { apiClient };
 export * from "@/lib/api/authClient";
 
-export function setupAuthInterceptors(client: AxiosInstance) {
+export function setupInterceptors(client: AxiosInstance) {
   client.interceptors.request.use(authInterceptor);
+  client.interceptors.request.use(contextInterceptor);
 }

--- a/frontend/agent_studio_desktop/src/lib/api/interceptors/contextInterceptor.ts
+++ b/frontend/agent_studio_desktop/src/lib/api/interceptors/contextInterceptor.ts
@@ -1,0 +1,21 @@
+import { InternalAxiosRequestConfig } from "axios";
+import { useAuthStore } from "@/stores/authStore";
+import { HEADERS } from "@/lib/api/constants/headers";
+
+export const contextInterceptor = (config: InternalAxiosRequestConfig) => {
+  const { userId, userInfo } = useAuthStore.getState();
+  const orgId = userInfo?.organization.id;
+  const agentId = import.meta.env.VITE_AGENT_ID;
+
+  if (userId) {
+    config.headers.set(HEADERS.USER_ID, userId);
+  }
+  if (orgId) {
+    config.headers.set(HEADERS.ORG_ID, orgId);
+  }
+  if (agentId) {
+    config.headers.set(HEADERS.AGENT_ID, agentId as string);
+  }
+
+  return config;
+};

--- a/frontend/agent_studio_desktop/src/lib/api/schemaClient.ts
+++ b/frontend/agent_studio_desktop/src/lib/api/schemaClient.ts
@@ -20,11 +20,15 @@ export const schemaClient = {
   },
 
   async testConnection(accessToken: string): Promise<Datasource> {
-    const response = await apiClient.post(`${API_ENDPOINTS.DATASOURCES}`, {
-      headers: {
-        [HEADERS.AUTHORIZATION]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
-      },
-    });
+    const response = await apiClient.post(
+      `${API_ENDPOINTS.DATASOURCES}/test`,
+      {},
+      {
+        headers: {
+          [HEADERS.AUTHORIZATION]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
+        },
+      }
+    );
     return response.data;
   },
 
@@ -55,6 +59,40 @@ export const schemaClient = {
       {
         headers: {
           [HEADERS.AUTHORIZATION]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
+        },
+      }
+    );
+    return response.data;
+  },
+
+  async scanSchema(
+    accessToken: string,
+    datasourceId: string
+  ): Promise<ScanSchemaResponse> {
+    const response = await apiClient.post<ScanSchemaResponse>(
+      `${API_ENDPOINTS.SCHEMAS}/scan`,
+      { datasourceId },
+      {
+        headers: {
+          [HEADERS.AUTHORIZATION]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
+          [HEADERS.CONTENT_TYPE]: CONTENT_TYPES.APPLICATION_JSON,
+        },
+      }
+    );
+    return response.data;
+  },
+
+  async registerSchema(
+    accessToken: string,
+    data: RegisterSchemaRequest
+  ): Promise<RegisterSchemaResponse> {
+    const response = await apiClient.post<RegisterSchemaResponse>(
+      `${API_ENDPOINTS.SCHEMAS}/register`,
+      data,
+      {
+        headers: {
+          [HEADERS.AUTHORIZATION]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
+          [HEADERS.CONTENT_TYPE]: CONTENT_TYPES.APPLICATION_JSON,
         },
       }
     );
@@ -104,6 +142,28 @@ export interface CreateSchemaRequest {
   name: string;
   schemas: TableSchema[];
   rawSchema: string;
+}
+
+export interface ScanSchemaResponse {
+  datasourceId: string;
+  schemas: TableSchema[];
+  rawSchema: string;
+}
+
+export interface RegisterSchemaRequest {
+  orgId: string;
+  userId: string;
+  agentId: string;
+  datasourceId: string;
+  name: string;
+  schemas: TableSchema[];
+  rawSchema: string;
+}
+
+export interface RegisterSchemaResponse {
+  id: string;
+  name: string;
+  rawJson: string;
 }
 
 export interface UpdateDatasourceRequest {


### PR DESCRIPTION
## 변경 사항
- 요청 헤더에 조직/사용자/에이전트 정보를 자동 추가하도록 인터셉터를 추가했습니다.
- 스키마 스캔과 등록을 위한 API 메서드를 구현했습니다.
- 데이터소스 상세 페이지를 새로 만들고 스키마 업로드 UI를 포함했습니다.
- 라우터에 상세 페이지 경로를 등록했습니다.